### PR TITLE
Add spinner for small screens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -113,6 +113,29 @@
       overflow: hidden;
     }
 
+    /* ローディングテキストのスタイル */
+    .loading-text {
+      margin-top: 40px;
+      color: #2c3e50;
+      font-size: 1.2rem;
+      font-weight: 500;
+      text-align: center;
+      opacity: 0;
+      animation: fadeInText 1s ease-in-out 0.5s forwards;
+      letter-spacing: 0.5px;
+    }
+
+    @keyframes fadeInText {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
     .loading-screen.hidden {
       opacity: 0;
       visibility: hidden;
@@ -135,6 +158,8 @@
     /* 小画面向けスピナー */
     .spinner-container {
       display: none;
+      flex-direction: column;
+      align-items: center;
     }
 
     .spinner {
@@ -144,6 +169,15 @@
       border-top-color: #ff7043;
       border-radius: 50%;
       animation: spin 1s linear infinite;
+      margin-bottom: 20px;
+    }
+
+    .spinner-text {
+      color: #2c3e50;
+      font-size: 1.1rem;
+      font-weight: 500;
+      text-align: center;
+      letter-spacing: 0.5px;
     }
 
     #roseSVG {
@@ -173,6 +207,7 @@
         align-items: center;
         width: 100vw;
         height: 100vh;
+        flex-direction: column;
       }
     }
 
@@ -1344,6 +1379,7 @@
     </div>
     <div class="spinner-container" id="spinnerContainer">
       <div class="spinner"></div>
+      <div class="spinner-text">過去問データを読み込み中...</div>
     </div>
   </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -132,6 +132,20 @@
       z-index: 1000;
     }
 
+    /* 小画面向けスピナー */
+    .spinner-container {
+      display: none;
+    }
+
+    .spinner {
+      width: 50px;
+      height: 50px;
+      border: 4px solid rgba(44, 62, 80, 0.3);
+      border-top-color: #ff7043;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
     #roseSVG {
       width: 450px;
       height: 450px;
@@ -147,6 +161,18 @@
         height: 350px;
         max-width: 80vmin;
         max-height: 80vmin;
+      }
+
+      .rose-loading-container {
+        display: none;
+      }
+
+      .spinner-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100vw;
+        height: 100vh;
       }
     }
 
@@ -1315,6 +1341,9 @@
               stroke-linecap="round" stroke-linejoin="round" opacity="0.6" 
               transform="translate(-1, -1)" style="filter: url(#softBlur)"/>
       </svg>
+    </div>
+    <div class="spinner-container" id="spinnerContainer">
+      <div class="spinner"></div>
     </div>
   </div>
 
@@ -2571,9 +2600,18 @@
     window.addEventListener('DOMContentLoaded', () => {
       // スクロールを無効にする
       disableScroll();
-      
-      // 正葉曲線アニメーションを開始
-      startRoseLoadingAnimation();
+
+      const isSmallScreen = window.matchMedia('(max-width: 480px)').matches;
+
+      // 正葉曲線アニメーションまたはスピナーを開始
+      if (isSmallScreen) {
+        const spinner = document.getElementById('spinnerContainer');
+        if (spinner) {
+          spinner.style.display = 'flex';
+        }
+      } else {
+        startRoseLoadingAnimation();
+      }
       
       // 初期化完了後のローディング画面制御
       initializeFilters().then(() => {
@@ -2584,10 +2622,12 @@
         setTimeout(() => {
           const elapsedTime = Date.now() - loadingStartTime;
           const remainingTime = Math.max(0, minDisplayTime - elapsedTime);
-          
+
           setTimeout(() => {
-            // fadeOutLoadingScreen();
-            // アニメーションが自然に終了するのを待つ
+            if (isSmallScreen) {
+              fadeOutLoadingScreen();
+            }
+            // 大画面ではアニメーションの終了を待つ
           }, remainingTime);
         }, 100);
       }).catch((error) => {


### PR DESCRIPTION
## Summary
- add CSS and markup for spinner
- hide rose animation when screen width is 480px or less
- show spinner and fade the loader after filters load on small devices

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68460887cf808328a48c3dcf0e89d62d