### PR TITLE
Fix accent color consistency across themes

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1355,11 +1355,12 @@
         --badge-hover-bg: rgba(90, 130, 170, 0.4);
         --file-bg: rgba(45, 45, 45, 0.8);
         --file-hover-bg: rgba(55, 55, 55, 0.9);
-        --accent-color: #5a9fd4;
-        --accent-color-end: #7bb3e0;
-        --accent-border: rgba(90, 159, 212, 0.4);
-        --accent-border-focus: rgba(90, 159, 212, 0.6);
-        --accent-option-bg: rgba(90, 159, 212, 0.2);
+        /* Use the same accent colors as the light theme */
+        --accent-color: #3498db;
+        --accent-color-end: #5dade2;
+        --accent-border: rgba(52, 152, 219, 0.4);
+        --accent-border-focus: rgba(52, 152, 219, 0.6);
+        --accent-option-bg: rgba(52, 152, 219, 0.2);
       }
       
       h1 {
@@ -1386,7 +1387,7 @@
       }
       
       select {
-        background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%235a9fd4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+        background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%233498db' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
       }
       
       .subject {
@@ -1433,13 +1434,13 @@
       }
       
       .clear-filters {
-        background: linear-gradient(135deg, rgba(90, 159, 212, 0.8) 0%, rgba(123, 179, 224, 0.8) 100%);
-        border: 2px solid rgba(90, 159, 212, 0.5);
+        background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-end) 100%);
+        border: 2px solid rgba(52, 152, 219, 0.5);
       }
-      
+
       .clear-filters:hover, .clear-filters:active {
-        background: linear-gradient(135deg, rgba(123, 179, 224, 0.9) 0%, rgba(160, 196, 232, 0.9) 100%);
-        box-shadow: 0 8px 25px rgba(90, 159, 212, 0.3);
+        background: linear-gradient(135deg, var(--accent-color-end) 0%, var(--accent-color) 100%);
+        box-shadow: 0 8px 25px rgba(52, 152, 219, 0.3);
       }
       
       .file-btn {


### PR DESCRIPTION
## Summary
- keep same accent palette for dark mode
- use accent colors for `.clear-filters` and select dropdown arrow

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6848f77988a883288746c7c4eb1d3208