### PR TITLE
Sync child item borders with accent theme

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -565,7 +565,7 @@
       left: 0;
       width: 4px;
       height: 100%;
-      background: linear-gradient(135deg, #ff9173 0%, #ff8a65 100%);
+      background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-end) 100%);
       border-radius: 0 2px 2px 0;
     }
     
@@ -645,7 +645,7 @@
       left: 0;
       width: 3px;
       height: 100%;
-      background: linear-gradient(135deg, #ff9173 0%, #ff8a65 100%);
+      background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-end) 100%);
       border-radius: 0 2px 2px 0;
     }
     
@@ -1490,11 +1490,11 @@
       }
       
       .child-page-item::before {
-        background: linear-gradient(135deg, rgba(90, 159, 212, 0.8) 0%, rgba(123, 179, 224, 0.7) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-end) 100%);
       }
       
       .child-file-item::before {
-        background: linear-gradient(135deg, rgba(90, 159, 212, 0.8) 0%, rgba(123, 179, 224, 0.7) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-end) 100%);
       }
       
       /* ページコンテンツのダークモード対応 */


### PR DESCRIPTION
## Summary
- make child page/file border gradients use `var(--accent-color)` and `var(--accent-color-end)`

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6848f7766af88328814db01fd3b35de6