### PR TITLE
Add offline fallback

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <div style="padding: 20px; text-align:center;">
+    <h1>Offline</h1>
+    <p>インターネットに接続されていません。</p>
+  </div>
+</body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,14 @@
-const CACHE_NAME = 'kakomon-cache-v1';
+const CACHE_NAME = 'kakomon-cache-v2';
 const STATIC_ASSETS = [
   '/',
   '/index.html',
   '/manifest.json',
-  '/images/favicon.ico'
+  '/style.css',
+  '/service-worker.js',
+  '/offline.html',
+  '/images/favicon.ico',
+  '/images/icon-192x192.png',
+  '/images/icon-512x512.png'
 ];
 
 self.addEventListener('install', event => {
@@ -39,7 +44,17 @@ self.addEventListener('fetch', event => {
 
   if (STATIC_ASSETS.includes(url.pathname) || url.origin === location.origin) {
     event.respondWith(
-      caches.match(event.request).then(resp => resp || fetch(event.request))
+      caches.match(event.request)
+        .then(resp => resp || fetch(event.request))
+        .catch(() => caches.match('/offline.html'))
+    );
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .catch(() => caches.match('/offline.html'))
     );
   }
 });


### PR DESCRIPTION
## Summary
- update service worker to cache all static assets
- add offline fallback logic and simple offline page

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68492ae278ac83288396678f5aa644aa