### PR TITLE
Add responsive filter toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -148,7 +148,8 @@
     </div>
     
     <!-- フィルタセクション -->
-    <div class="filters">
+    <button id="filterToggle" class="filter-toggle" aria-expanded="false" aria-controls="filtersContainer">Filters</button>
+    <div class="filters" id="filtersContainer">
       <div class="filter-row">
         <div class="filter-group">
           <label class="filter-label">教科</label>
@@ -1466,6 +1467,15 @@
 
     // ページ読み込み時の初期化
     window.addEventListener('DOMContentLoaded', () => {
+      const filterToggle = document.getElementById('filterToggle');
+      const filtersContainer = document.getElementById('filtersContainer');
+      if (filterToggle && filtersContainer) {
+        filterToggle.addEventListener('click', () => {
+          const expanded = filterToggle.getAttribute('aria-expanded') === 'true';
+          filterToggle.setAttribute('aria-expanded', String(!expanded));
+          filtersContainer.classList.toggle('expanded', !expanded);
+        });
+      }
       // スクロールを無効にする
       disableScroll();
 

--- a/public/style.css
+++ b/public/style.css
@@ -1571,7 +1571,31 @@
         color: #c8d9ed;
       }
       
-      .child-page-text tr:nth-child(even) td {
+    .child-page-text tr:nth-child(even) td {
         background: rgba(80, 80, 80, 0.3);
-      }
     }
+}
+
+/* フィルタ表示切り替えボタン */
+.filter-toggle {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .filter-toggle {
+    display: block;
+    margin: 10px 0;
+  }
+  .filters {
+    display: none;
+  }
+  .filters.expanded {
+    display: flex;
+  }
+}
+
+@media (min-width: 601px) {
+  .filter-toggle {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Filters toggle button for mobile
- hide and reveal filters with CSS on small screens
- manage expanded state with JS for accessibility

## Testing
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68492b1600e48328a12b302b27c0675e