### PR TITLE
Make filter button sticky on small screens

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1597,6 +1597,11 @@
   .filter-toggle {
     display: block;
     margin: 10px 0;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: var(--panel-bg);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
   .filters {
     display: none;


### PR DESCRIPTION
## Summary
- ensure `.filter-toggle` stays visible on mobile by making it sticky
- add slight background and shadow for visibility when scrolling

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6849675ca1048328897620e8570ba8a1