### PR TITLE
Sticky search box on small screens

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1598,10 +1598,16 @@
     display: block;
     margin: 10px 0;
     position: sticky;
-    top: 0;
+    top: 140px; /* avoid overlap with pinned search bar */
     z-index: 1000;
     background: var(--panel-bg);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  .search-box {
+    position: sticky;
+    top: 0;
+    z-index: 999;
   }
 
   .mobile-filter {


### PR DESCRIPTION
## Summary
- keep the search bar pinned on viewports under 600px
- offset the filter toggle so it doesn't overlap the search bar

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68496f8811a08328a941bc6edacec2a0