### PR TITLE
Add live search input debounce

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -479,6 +479,14 @@
       }
     }
 
+    function debounce(fn, ms) {
+      let timer;
+      return function(...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn.apply(this, args), ms);
+      };
+    }
+
     async function search() {
       const query = document.getElementById('searchInput').value;
       const subject = document.getElementById('subjectFilter').value;
@@ -596,6 +604,8 @@
         resultsDiv.innerHTML = '<div class="error">検索中にエラーが発生しました。</div>';
       }
     }
+
+    const debouncedSearch = debounce(search, 350);
 
     // バックグラウンドでページ詳細をプリロード
     async function preloadPageDetails(pageId) {
@@ -1522,6 +1532,9 @@
         search();
       }
     });
+
+    // 入力時に自動検索
+    document.getElementById('searchInput')?.addEventListener('input', debouncedSearch);
 
     // initializeFilters関数をPromiseを返すように修正
     async function initializeFilters() {


### PR DESCRIPTION
## Summary
- implement small `debounce` helper
- create `debouncedSearch` wrapped around `search`
- add `input` event handler so search runs while typing

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684972c0393883288c77d1fdf0e032ea