### PR TITLE
Improve layout with flexbox

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -210,7 +210,24 @@
       max-width: 1200px;
       margin: 0 auto;
       padding: 20px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       animation: fadeInUp 0.8s ease-out;
+    }
+
+    #results {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 20px;
+      width: 100%;
+    }
+
+    @media (min-width: 1025px) {
+      #results {
+        grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+        justify-content: center;
+      }
     }
     
     @keyframes fadeInUp {
@@ -412,6 +429,10 @@
       box-shadow: 0 8px 32px rgba(31, 38, 135, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.2);
       transition: all 0.3s ease;
       animation: slideIn 0.6s ease-out;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      word-break: break-word;
     }
     
     .result-item:hover {


### PR DESCRIPTION
## Summary
- center content in `.container` using flexbox
- display search results in a responsive grid
- prevent overflow in `.result-item`

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d33a902c832890c0dc02efb8bdcf