### PR TITLE
Enhance mobile slide button UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1681,7 +1681,16 @@
       let startX = 0;
       let currentX = 0;
       let buttonRect = null;
-      const slideThreshold = 60; // 60px以上で自動完了
+      const slideThreshold = 30; // 30px以上で自動完了
+
+      // 初回のみ引っ張りアニメーション
+      if (!localStorage.getItem('slideHintShown')) {
+        button.classList.add('hint');
+        setTimeout(() => {
+          button.classList.remove('hint');
+          localStorage.setItem('slideHintShown', 'true');
+        }, 700);
+      }
       
       function getMaxSlideDistance() {
         // 右から左に最大80px引っ張る
@@ -1696,6 +1705,7 @@
         
         handle.style.transition = 'none';
         button.classList.add('dragging');
+        button.classList.add('touch-active');
         
         // Google Analytics: スライド開始イベント
         sendGAEvent('slide_start', 'user_interaction', 'orange_vertical_slider');
@@ -1734,6 +1744,7 @@
           isDragging = false;
         handle.style.transition = 'transform 0.4s cubic-bezier(0.25, 0.1, 0.25, 1)'; /* より滑らかなease-in-out */
         button.classList.remove('dragging');
+        button.classList.remove('touch-active');
         button.classList.remove('slide-threshold-reached');
         
         const slideDistance = Math.abs(currentX);
@@ -1772,6 +1783,10 @@
       handle.addEventListener('touchstart', handleStart, { passive: false });
       document.addEventListener('touchmove', handleMove, { passive: false });
       document.addEventListener('touchend', handleEnd, { passive: false });
+
+      // ホバー・フォーカスエフェクト
+      button.addEventListener('mouseenter', () => button.classList.add('hovered'));
+      button.addEventListener('mouseleave', () => button.classList.remove('hovered'));
     }
 
     // 従来のトグル関数は互換性のため保持
@@ -1792,15 +1807,13 @@
   </script>  <!-- Vertical Orange Slider for mobile -->
   <div id="slideSearchButton" class="slide-search-button vertical-slide">
     <div class="slide-button-track">
-      <div class="slide-button-handle" id="slideHandle">
-        <span class="slide-icon">&lt;&lt;</span>
-      </div>
+      <div class="slide-button-handle" id="slideHandle"></div>
       <div class="slide-button-text">スライドして検索</div>
     </div>
   </div>
 
   <!-- Search Panel Overlay -->
-  <div id="searchPanelOverlay" class="search-panel-overlay"></div>
+  <div id="searchPanelOverlay" class="search-panel-overlay hidden"></div>
   </div> <!-- メインコンテンツ終了 -->
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -314,6 +314,10 @@
       overflow: hidden;
       border: 2px solid rgba(255, 255, 255, 0.3);
     }
+
+    .slide-search-button.vertical-slide.hint .slide-button-handle {
+      animation: slidePullHint 0.6s ease-out;
+    }
     
     button::before {
       content: '';
@@ -1589,25 +1593,27 @@
   @media (max-width: 767px) {
     .search-panel {
       position: fixed;
+      top: 0;
       bottom: 0;
-      left: 0;
       right: 0;
-      width: 100%;
-      max-height: 80vh;
+      width: 80%;
+      max-width: 320px;
       padding: 0;
       background: var(--panel-bg);
       backdrop-filter: blur(25px);
-      border-radius: 25px 25px 0 0;
-      transform: translateY(100%);
-      transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-      box-shadow: 0 -8px 32px rgba(31, 38, 135, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+      border-radius: 20px 0 0 20px;
+      transform: translateX(100%);
+      opacity: 0;
+      transition: transform 0.4s ease, opacity 0.4s ease;
+      box-shadow: -8px 0 32px rgba(31, 38, 135, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3);
       z-index: 1000;
-      border-top: 1px solid rgba(255, 255, 255, 0.4);
+      border-left: 1px solid rgba(255, 255, 255, 0.4);
       overflow-y: auto;
     }
 
     .search-panel.open {
-      transform: translateY(0);
+      transform: translateX(0);
+      opacity: 1;
     }
 
     /* Panel header styling */
@@ -1699,7 +1705,31 @@
       align-items: center;
       justify-content: center;
       --slide-progress: 0;
-    }.slide-search-button.vertical-slide:hover {
+    }
+
+.slide-search-button.vertical-slide::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 0;
+      height: 0;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(255,255,255,0.6) 0%, rgba(255,255,255,0) 70%);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.4s ease, width 0.4s ease, height 0.4s ease;
+    }
+
+    .slide-search-button.vertical-slide.hovered::before,
+    .slide-search-button.vertical-slide.touch-active::before {
+      width: 120px;
+      height: 120px;
+      opacity: 1;
+    }
+
+    .slide-search-button.vertical-slide:hover {
       transform: translateY(-50%) translateX(50px); /* ホバーで少し出てくる */
       box-shadow: 
         -12px 0 40px rgba(255, 140, 66, 0.5),
@@ -1800,8 +1830,14 @@
       }
     }
 
+    @keyframes slidePullHint {
+      0% { transform: translateX(0); }
+      50% { transform: translateX(-6px); }
+      100% { transform: translateX(0); }
+    }
+
     /* オーバーレイスタイル */
-    .search-overlay {
+    .search-panel-overlay {
       position: fixed;
       top: 0;
       left: 0;
@@ -1809,15 +1845,22 @@
       height: 100vh;
       background: rgba(0, 0, 0, 0.25);
       z-index: 999;
-      transition: all 0.4s cubic-bezier(0.25, 0.1, 0.25, 1);
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.4s ease;
+    }
+
+    .search-panel-overlay.hidden {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    .search-panel-overlay:not(.hidden) {
       opacity: 1;
       visibility: visible;
     }
 
-    .search-overlay.hidden {
-      opacity: 0;
-      visibility: hidden;
-    }.slide-search-button.vertical-slide .slide-button-text {
+    .slide-search-button.vertical-slide .slide-button-text {
       font-size: 12px;
       font-weight: 700;
       color: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
## Summary
- redesign slide button with glass look
- animate button hint once on first visit
- open search panel from the right with overlay fade
- add hover/touch light effect and adjust slide threshold

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684acdc7c570832891f9706f5fc3ad3c