### PR TITLE
Add slide hint and panel animation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1517,13 +1517,15 @@
           fadeOutLoadingScreen();
         }, 2500); // エラー時の表示時間も短縮（3秒→2.5秒）
       });      // モバイルでの初期状態設定
-      if (window.innerWidth <= 767) {        const panel = document.getElementById('searchPanel');
+      if (window.innerWidth <= 767) {
+        const panel = document.getElementById('searchPanel');
         const slideButton = document.getElementById('slideSearchButton');
         if (panel && slideButton) {
-          // 初期状態: モバイルでパネルは開いている、スライドボタンは隠れている
-          panel.classList.add('open');
-          slideButton.classList.add('hidden');
+          // 初期状態: モバイルではパネルを閉じてスライドボタンを表示
+          panel.classList.remove('open');
+          slideButton.classList.remove('hidden');
           initializeSlideButton(); // スライドボタンを初期化
+          showInitialSlideHint();
         }
       }
     });
@@ -1571,13 +1573,14 @@
           panel.classList.add('open');
           slideButton.classList.add('hidden');
         } else {
-          // モバイル: 初期状態はパネル開いている、スライドボタンは隠れている
-          panel.classList.add('open');
-          slideButton.classList.add('hidden');
+          // モバイル: パネルを閉じてスライドボタンを表示
+          panel.classList.remove('open');
+          slideButton.classList.remove('hidden');
           resetSlideButton();
           if (!slideButton.hasAttribute('data-initialized')) {
             initializeSlideButton();
             slideButton.setAttribute('data-initialized', 'true');
+            showInitialSlideHint();
           }
         }
       }
@@ -1618,7 +1621,7 @@
       
       // オーバーレイを表示
       if (overlay) {
-        overlay.classList.remove('hidden');
+        overlay.classList.add('active');
       }
       
       panel.classList.add('open');
@@ -1649,7 +1652,7 @@
       
       // オーバーレイを隠す
       if (overlay) {
-        overlay.classList.add('hidden');
+        overlay.classList.remove('active');
       }
       
       panel.classList.remove('open');
@@ -1681,7 +1684,13 @@
       let startX = 0;
       let currentX = 0;
       let buttonRect = null;
-      const slideThreshold = 60; // 60px以上で自動完了
+
+      // ホバー・タッチ時の光エフェクト
+      button.addEventListener('mouseenter', () => button.classList.add('hover-effect'));
+      button.addEventListener('mouseleave', () => button.classList.remove('hover-effect'));
+      button.addEventListener('touchstart', () => button.classList.add('touch-active'));
+      button.addEventListener('touchend', () => button.classList.remove('touch-active'));
+      const slideThreshold = 30; // 30px以上で自動完了
       
       function getMaxSlideDistance() {
         // 右から左に最大80px引っ張る
@@ -1719,7 +1728,7 @@
         const progress = Math.abs(currentX) / Math.abs(getMaxSlideDistance());
         button.style.setProperty('--slide-progress', progress);
         
-        // 60px以上スライドした場合の視覚的フィードバック
+        // 30px以上スライドした場合の視覚的フィードバック
         if (Math.abs(currentX) >= slideThreshold) {
           button.classList.add('slide-threshold-reached');
         } else {
@@ -1739,7 +1748,7 @@
         const slideDistance = Math.abs(currentX);
         
         if (slideDistance >= slideThreshold) {
-          // 60px以上スライド完了 - 検索パネルを開く
+          // 30px以上スライド完了 - 検索パネルを開く
           const maxDistance = Math.abs(getMaxSlideDistance());
           handle.style.transform = `translateX(${getMaxSlideDistance()}px)`;
           button.classList.add('slide-completed');
@@ -1771,7 +1780,19 @@
       // タッチイベント
       handle.addEventListener('touchstart', handleStart, { passive: false });
       document.addEventListener('touchmove', handleMove, { passive: false });
-      document.addEventListener('touchend', handleEnd, { passive: false });
+  document.addEventListener('touchend', handleEnd, { passive: false });
+    }
+
+    function showInitialSlideHint() {
+      const button = document.getElementById('slideSearchButton');
+      if (!button) return;
+      if (!localStorage.getItem('slideHintShown')) {
+        button.classList.add('initial-hint');
+        button.addEventListener('animationend', () => {
+          button.classList.remove('initial-hint');
+        }, { once: true });
+        localStorage.setItem('slideHintShown', 'true');
+      }
     }
 
     // 従来のトグル関数は互換性のため保持
@@ -1792,9 +1813,7 @@
   </script>  <!-- Vertical Orange Slider for mobile -->
   <div id="slideSearchButton" class="slide-search-button vertical-slide">
     <div class="slide-button-track">
-      <div class="slide-button-handle" id="slideHandle">
-        <span class="slide-icon">&lt;&lt;</span>
-      </div>
+      <div class="slide-button-handle" id="slideHandle"></div>
       <div class="slide-button-text">スライドして検索</div>
     </div>
   </div>

--- a/public/style.css
+++ b/public/style.css
@@ -1589,25 +1589,27 @@
   @media (max-width: 767px) {
     .search-panel {
       position: fixed;
+      top: 40px;
       bottom: 0;
-      left: 0;
       right: 0;
+      left: 0;
       width: 100%;
-      max-height: 80vh;
-      padding: 0;
+      max-width: 100%;
+      padding: 25px 20px;
       background: var(--panel-bg);
       backdrop-filter: blur(25px);
-      border-radius: 25px 25px 0 0;
-      transform: translateY(100%);
-      transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-      box-shadow: 0 -8px 32px rgba(31, 38, 135, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+      border-radius: 20px 0 0 20px;
+      transform: translateX(100%);
+      opacity: 0;
+      transition: transform 0.4s ease, opacity 0.4s ease;
+      box-shadow: -8px 0 32px rgba(31, 38, 135, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3);
       z-index: 1000;
-      border-top: 1px solid rgba(255, 255, 255, 0.4);
       overflow-y: auto;
     }
 
     .search-panel.open {
-      transform: translateY(0);
+      transform: translateX(0);
+      opacity: 1;
     }
 
     /* Panel header styling */
@@ -1693,13 +1695,45 @@
       backdrop-filter: blur(20px);
       z-index: 1001;      overflow: hidden;
       cursor: grab;
-      transition: all 0.4s cubic-bezier(0.25, 0.1, 0.25, 1); /* より滑らかなease-in-out */
-      display: flex;
+        transition: all 0.4s cubic-bezier(0.25, 0.1, 0.25, 1);
+        display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
       --slide-progress: 0;
-    }.slide-search-button.vertical-slide:hover {
+    }
+
+    .slide-search-button.vertical-slide::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 50%;
+      width: 120px;
+      height: 120px;
+      transform: translate(-70%, -50%);
+      background: radial-gradient(circle, rgba(255,255,255,0.5), rgba(255,255,255,0) 70%);
+      opacity: 0;
+      pointer-events: none;
+      filter: blur(8px);
+      transition: opacity 0.4s ease;
+    }
+
+    .slide-search-button.vertical-slide.hover-effect::before,
+    .slide-search-button.vertical-slide.touch-active::before {
+      opacity: 1;
+    }
+
+    @keyframes slideHint {
+      0% { transform: translateY(-50%) translateX(60px); }
+      50% { transform: translateY(-50%) translateX(54px); }
+      100% { transform: translateY(-50%) translateX(60px); }
+    }
+
+    .slide-search-button.vertical-slide.initial-hint {
+      animation: slideHint 0.6s ease-out;
+    }
+
+    .slide-search-button.vertical-slide:hover {
       transform: translateY(-50%) translateX(50px); /* ホバーで少し出てくる */
       box-shadow: 
         -12px 0 40px rgba(255, 140, 66, 0.5),
@@ -1716,12 +1750,9 @@
     /* パネル開いている時のスライダー状態 */
     .slide-search-button.vertical-slide.panel-open {
       animation: none; /* パネル開いている時は点滅停止 */
+      transform: translateY(-50%) translateX(100%);
     }
 
-    .slide-search-button.vertical-slide.panel-open .slide-icon {
-      animation: none; /* パネル開いている時は点滅停止 */
-      opacity: 1;
-    }
 
     .slide-search-button.vertical-slide.dragging {
       cursor: grabbing;
@@ -1779,26 +1810,6 @@
         0 6px 14px rgba(0, 0, 0, 0.15),
         inset 0 1px 0 rgba(255, 255, 255, 1),
         inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-    }    .slide-search-button.vertical-slide .slide-icon {
-      font-size: 24px;
-      color: #ff6b1a;
-      filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
-      transition: all 0.3s ease;
-      font-weight: bold;
-      animation: slideIconPulse 2s ease-in-out infinite;
-    }
-
-    /* <<アイコンの点滅アニメーション */
-    @keyframes slideIconPulse {
-      0%, 100% {
-        opacity: 1;
-        transform: scale(1);
-      }
-      50% {
-        opacity: 0.6;
-        transform: scale(1.1);
-      }
-    }
 
     /* オーバーレイスタイル */
     .search-overlay {
@@ -1817,7 +1828,26 @@
     .search-overlay.hidden {
       opacity: 0;
       visibility: hidden;
-    }.slide-search-button.vertical-slide .slide-button-text {
+    }
+
+    .search-panel-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: rgba(0, 0, 0, 0.4);
+      z-index: 900;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.4s ease;
+    }
+
+    .search-panel-overlay.active {
+      opacity: 1;
+      visibility: visible;
+    }
+.slide-search-button.vertical-slide .slide-button-text {
       font-size: 12px;
       font-weight: 700;
       color: rgba(255, 255, 255, 0.95);
@@ -1842,12 +1872,6 @@
         inset 0 1px 0 rgba(255, 255, 255, 1),
         inset 0 -1px 0 rgba(0, 0, 0, 0.2);
       background: linear-gradient(135deg, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0.9) 100%);
-    }    .slide-search-button.vertical-slide.dragging .slide-icon {
-      color: #e55a00;
-      transform: scale(1.2);
-      filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.3));
-      animation: none; /* ドラッグ中は点滅を停止 */
-    }
 
     /* 60px以上スライドした時の視覚的フィードバック */
     .slide-search-button.vertical-slide.slide-threshold-reached {
@@ -1871,12 +1895,6 @@
       transform: scale(1.2);
     }
 
-    .slide-search-button.vertical-slide.slide-threshold-reached .slide-icon {
-      color: #d14900;
-      transform: scale(1.3);
-      filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.4));
-      animation: none; /* 閾値到達時も点滅を停止 */
-    }/* Search button styling for mobile */
     .search-btn {
       background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-color-end) 100%);
       min-height: 50px;
@@ -1917,12 +1935,6 @@
       background: linear-gradient(180deg, #ffb87c 0%, #ff9853 50%, #ff7a2b 100%);
     }
 
-    .slide-search-button.vertical-slide .slide-icon {
-      color: #ff7a2b;
-    }
-
-    .slide-search-button.vertical-slide.dragging .slide-icon {
-      color: #e86010;
     }
 
     .slide-search-button.vertical-slide.slide-threshold-reached {


### PR DESCRIPTION
## Summary
- refactor mobile search panel to slide in from the right
- add radial hover/touch effect to the slide button
- show one–time hint animation for the button
- adjust JS logic for opening/closing panel

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad40555dc8328adcdd0fa6e912131