### PR TITLE
スライドボタンのスライドしきい値を60pxから40pxに変更し、ボタンのサイズと位置を調整

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1650,12 +1650,11 @@
       let isDragging = false;
       let startX = 0;
       let currentX = 0;
-      let buttonRect = null;
-      const slideThreshold = 60; // 60px以上で自動完了
+      let buttonRect = null;      const slideThreshold = 40; // 40px以上で自動完了
       
       function getMaxSlideDistance() {
-        // 右から左に最大80px引っ張る
-        return -80;
+        // 右から左に最大60px引っ張る
+        return -60;
       }
       
       function handleStart(e) {
@@ -1689,7 +1688,7 @@
         const progress = Math.abs(currentX) / Math.abs(getMaxSlideDistance());
         button.style.setProperty('--slide-progress', progress);
         
-        // 60px以上スライドした場合の視覚的フィードバック
+        // 40px以上スライドした場合の視覚的フィードバック
         if (Math.abs(currentX) >= slideThreshold) {
           button.classList.add('slide-threshold-reached');
         } else {
@@ -1709,7 +1708,7 @@
         const slideDistance = Math.abs(currentX);
         
         if (slideDistance >= slideThreshold) {
-          // 60px以上スライド完了 - 検索パネルを開く
+          // 40px以上スライド完了 - 検索パネルを開く
           const maxDistance = Math.abs(getMaxSlideDistance());
           track.style.transform = `translateX(${getMaxSlideDistance()}px)`;
           button.classList.add('slide-completed');

--- a/public/style.css
+++ b/public/style.css
@@ -1674,9 +1674,9 @@
       position: fixed;
       top: 70%;
       right: 0;
-      width: 60px;
-      height: 180px;
-      transform: translateY(-50%) translateX(45px); /* 初期状態で15pxだけ見える (60px - 45px = 15px) */
+      width: 45px;
+      height: 140px;
+      transform: translateY(-50%) translateX(35px); /* 初期状態で10pxだけ見える (45px - 35px = 10px) */
       background:
         linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.08) 100%),
         linear-gradient(180deg, rgba(255, 140, 66, 0.7) 0%, rgba(255, 107, 26, 0.6) 50%, rgba(229, 90, 0, 0.5) 100%);
@@ -1698,15 +1698,15 @@
       justify-content: center;
       --slide-progress: 0;
     }    .slide-search-button.vertical-slide:hover {
-      transform: translateY(-50%) translateX(50px); /* ホバーで少し出てくる */      box-shadow: 
+      transform: translateY(-50%) translateX(30px); /* ホバーで少し出てくる */box-shadow: 
         -9px 0 30px rgba(255, 140, 66, 0.4),
         -4px 0 15px rgba(255, 107, 26, 0.3),
         -2px 0 9px rgba(229, 90, 0, 0.25),
         inset 2px 2px 12px rgba(255, 255, 255, 0.3),
         inset -2px -2px 12px rgba(0, 0, 0, 0.1);
       cursor: grab;
-    }.slide-search-button.vertical-slide.hidden {
-      transform: translateY(-50%) translateX(80px); /* 完全に隠れる */
+    }    .slide-search-button.vertical-slide.hidden {
+      transform: translateY(-50%) translateX(60px); /* 完全に隠れる */
       pointer-events: none;
     }
 
@@ -1738,8 +1738,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
-      padding: 8px 4px;
+      justify-content: center;      padding: 6px 3px;
       cursor: grab;
       transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
     }
@@ -1750,14 +1749,13 @@
 
     .slide-search-button.vertical-slide .slide-text {
       display: none; /* 文字を削除 */
-    }.slide-search-button.vertical-slide .slide-icon {
-      font-size: 24px;
+    }    .slide-search-button.vertical-slide .slide-icon {
+      font-size: 20px;
       color: #ff6b1a;
       filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
       transition: all 0.3s ease;
-      font-weight: bold;
-      animation: slideIconPulse 2s ease-in-out infinite;
-      margin-bottom: 16px;
+      font-weight: bold;      animation: slideIconPulse 2s ease-in-out infinite;
+      margin-bottom: 12px;
     }
 
     /* <<アイコンの点滅アニメーション */
@@ -1840,15 +1838,14 @@
       transform: scale(1.2);
       filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.3));
       animation: none; /* ドラッグ中は点滅を停止 */
-    }    /* 60px以上スライドした時の視覚的フィードバック */
+    }    /* 40px以上スライドした時の視覚的フィードバック */
     .slide-search-button.vertical-slide.slide-threshold-reached {
       background: linear-gradient(180deg, #ffaa6b 0%, #ff8c42 30%, #ff6b1a 70%, #e55a00 100%);      box-shadow: 
-        -18px 0 45px rgba(255, 140, 66, 0.6),
-        -9px 0 22px rgba(255, 107, 26, 0.5),
+        -18px 0 45px rgba(255, 140, 66, 0.6),        -9px 0 22px rgba(255, 107, 26, 0.5),
         -4px 0 15px rgba(229, 90, 0, 0.4),
         inset 2px 2px 20px rgba(255, 255, 255, 0.4),
         inset -2px -2px 20px rgba(0, 0, 0, 0.18);
-      transform: translateY(-50%) translateX(40px) scale(1.05);
+      transform: translateY(-50%) translateX(25px) scale(1.05);
     }
 
     .slide-search-button.vertical-slide.slide-threshold-reached .slide-icon {


### PR DESCRIPTION
This pull request updates the sliding search button functionality and its associated styles in `public/index.html` and `public/style.css`. The changes primarily focus on reducing the sliding threshold, adjusting dimensions, and refining the visual design for better usability and aesthetics.

### Functional Changes:
* Reduced the sliding threshold from 60px to 40px for triggering actions like opening the search panel and providing visual feedback. (`public/index.html`) [[1]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL1653-R1657) [[2]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL1692-R1691) [[3]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL1712-R1711)

### Visual Design Updates:
* Adjusted button dimensions (width reduced from 60px to 45px, height reduced from 180px to 140px) and modified initial visibility and hover behavior. (`public/style.css`) [[1]](diffhunk://#diff-46467272678c3da621692b13b96d47ed25128fa8027d8dbedd84684c6336fb51L1677-R1679) [[2]](diffhunk://#diff-46467272678c3da621692b13b96d47ed25128fa8027d8dbedd84684c6336fb51L1701-R1709)
* Reduced font size of the slide icon from 24px to 20px and adjusted its margin for a more compact design. (`public/style.css`)
* Updated padding and alignment for the button to refine its appearance. (`public/style.css`)
* Tweaked visual feedback styles for the button when the sliding threshold is reached, including changes to background, box-shadow, and transform properties. (`public/style.css`)