### PR TITLE
Add class for child page button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -744,36 +744,13 @@
               // 子ページの詳細を表示するボタン
               const showChildPageBtn = document.createElement('button');
               showChildPageBtn.textContent = '子ページを表示';
-                showChildPageBtn.style.cssText = `
-                padding: 12px 20px;
-                color: white;
-                border: none;
-                border-radius: 12px;
-                cursor: pointer;
-                font-size: 14px;
-                font-weight: 500;
-                transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-                position: relative;
-                overflow: hidden;
-                backdrop-filter: blur(10px);
-                border: 1px solid rgba(255, 255, 255, 0.2);
-              `;
-              
-              // CSS変数を使用してテーマに対応
-              const accentColor = getComputedStyle(document.documentElement).getPropertyValue('--accent-color').trim();
-              const accentColorEnd = getComputedStyle(document.documentElement).getPropertyValue('--accent-color-end').trim();
-              
-              showChildPageBtn.style.background = `linear-gradient(135deg, ${accentColor} 0%, ${accentColorEnd} 100%)`;
-              showChildPageBtn.style.boxShadow = `0 4px 12px ${accentColor.replace(/rgba\([^,]+,[^,]+,[^,]+,[^)]+\)/, 'rgba(52, 152, 219, 0.3)')}`;
-              
+              showChildPageBtn.classList.add('child-page-btn');
+
+              // ホバー時のアニメーションはJSで制御
               showChildPageBtn.onmouseover = () => {
-                showChildPageBtn.style.background = `linear-gradient(135deg, ${accentColorEnd} 0%, ${accentColor} 100%)`;
-                showChildPageBtn.style.boxShadow = `0 8px 20px ${accentColor.replace(/rgba\([^,]+,[^,]+,[^,]+,[^)]+\)/, 'rgba(52, 152, 219, 0.4)')}`;
                 showChildPageBtn.style.transform = 'translateY(-3px) scale(1.02)';
               };
               showChildPageBtn.onmouseout = () => {
-                showChildPageBtn.style.background = `linear-gradient(135deg, ${accentColor} 0%, ${accentColorEnd} 100%)`;
-                showChildPageBtn.style.boxShadow = `0 4px 12px ${accentColor.replace(/rgba\([^,]+,[^,]+,[^,]+,[^)]+\)/, 'rgba(52, 152, 219, 0.3)')}`;
                 showChildPageBtn.style.transform = 'translateY(0) scale(1)';
               };
               showChildPageBtn.onclick = () => {

--- a/public/style.css
+++ b/public/style.css
@@ -775,13 +775,37 @@
     }
     
     .file-btn.open-tab {
-      background: 
+      background:
         var(--iridescent-button),
         radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35) 0%, transparent 70%),
         radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.25) 0%, transparent 70%),
         linear-gradient(135deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0.06) 100%);
       background-size: 200% 200%, 100% 100%, 100% 100%, 100% 100%;
       animation: iridescent 11s ease-in-out infinite;
+    }
+
+    /* 子ページ表示ボタン */
+    .child-page-btn {
+      padding: 12px 20px;
+      color: var(--text-color);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      border: 2px solid transparent;
+      border-radius: 12px;
+      background:
+        var(--panel-bg) padding-box,
+        var(--iridescent-button) border-box;
+      background-size: 100% 100%, 200% 200%;
+      backdrop-filter: blur(10px);
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow:
+        0 6px 20px rgba(0, 0, 0, 0.1),
+        inset 0 2px 6px rgba(255, 255, 255, 0.4),
+        0 0 25px rgba(255, 255, 255, 0.2);
+      position: relative;
+      overflow: hidden;
+      animation: iridescent 10s ease-in-out infinite;
     }
     
     /* 子ページ関連のスタイル */


### PR DESCRIPTION
## Summary
- create `.child-page-btn` glass button style with animated rainbow border
- apply new class instead of inline styles when creating child page buttons
- keep only hover transforms and GA events in script

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687799478d008328b33bcac6306757de