### PR TITLE
Add standalone page details view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -547,25 +547,12 @@
           resultDiv.appendChild(titleDiv);
           resultDiv.appendChild(metaDiv);
           
-          // クリックして詳細を表示するリンク
-          const showDetailsLink = document.createElement('a');
-          showDetailsLink.textContent = 'クリックしてファイルを表示';
-          showDetailsLink.href = '#';
+          // クリックして別ページで詳細を表示するボタン
+          const showDetailsLink = document.createElement('button');
+          showDetailsLink.textContent = '開く';
           showDetailsLink.className = 'show-details-btn';
-          showDetailsLink.onclick = (e) => {
-            e.preventDefault();
-            
-            // 既に詳細が表示されている場合、処理中の場合、または削除済みの場合は何もしない
-            if (showDetailsLink.style.display === 'none' || 
-                showDetailsLink.style.pointerEvents === 'none' ||
-                showDetailsLink.textContent === '読み込み中...' ||
-                !showDetailsLink.parentNode) {
-              return;
-            }
-            
-            // Google Analytics: ページ詳細表示イベントを追跡
-            trackPageDetailsView(item.properties.Name?.title?.[0]?.text?.content || 'Unknown Page');
-            showPageDetails(item.id, resultDiv, showDetailsLink);
+          showDetailsLink.onclick = () => {
+            window.location.href = '/page.html?pageId=' + item.id;
           };
           
           resultDiv.appendChild(showDetailsLink);

--- a/public/page.html
+++ b/public/page.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ページ詳細</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <a href="/index.html" class="back-link">戻る</a>
+    <h1 id="pageTitle"></h1>
+    <div id="pageDetails"></div>
+  </div>
+
+  <script>
+    function getQueryParam(name) {
+      return new URLSearchParams(window.location.search).get(name);
+    }
+
+    function formatProperty(property) {
+      if (!property) return '';
+      if (property.type === 'title') {
+        return (property.title || []).map(t => t.plain_text).join('');
+      } else if (property.type === 'multi_select') {
+        return (property.multi_select || []).map(s => s.name).join(', ');
+      } else if (property.type === 'select' && property.select) {
+        return property.select.name;
+      } else if (property.type === 'date' && property.date) {
+        return property.date.start;
+      } else if (property.type === 'number' && property.number !== null) {
+        return property.number.toString();
+      } else if (property.type === 'rich_text') {
+        return (property.rich_text || []).map(t => t.plain_text).join('');
+      }
+      return '';
+    }
+
+    function hasActualContent(content) {
+      if (!content || content.length === 0) return false;
+      const nonChildPageContent = content.filter(block => block.type !== 'child_page');
+      for (const block of nonChildPageContent) {
+        if (block.type === 'paragraph' && block.paragraph.rich_text) {
+          const text = block.paragraph.rich_text.map(t => t.plain_text).join('').trim();
+          if (text) return true;
+        } else if (block.type === 'heading_1' && block.heading_1.rich_text) {
+          const text = block.heading_1.rich_text.map(t => t.plain_text).join('').trim();
+          if (text) return true;
+        } else if (block.type === 'heading_2' && block.heading_2.rich_text) {
+          const text = block.heading_2.rich_text.map(t => t.plain_text).join('').trim();
+          if (text) return true;
+        } else if (block.type === 'heading_3' && block.heading_3.rich_text) {
+          const text = block.heading_3.rich_text.map(t => t.plain_text).join('').trim();
+          if (text) return true;
+        } else if (block.type === 'bulleted_list_item' && block.bulleted_list_item.rich_text) {
+          const text = block.bulleted_list_item.rich_text.map(t => t.plain_text).join('').trim();
+          if (text) return true;
+        } else if (block.type === 'numbered_list_item' && block.numbered_list_item.rich_text) {
+          const text = block.numbered_list_item.rich_text.map(t => t.plain_text).join('').trim();
+          if (text) return true;
+        } else if (block.type === 'table_row' && block.table_row && block.table_row.cells) {
+          const hasContent = block.table_row.cells.some(cell =>
+            cell.some(text => text.plain_text.trim())
+          );
+          if (hasContent) return true;
+        }
+      }
+      return false;
+    }
+
+    function parseMarkdownToHTML(markdown) {
+      if (!markdown) return '';
+      const lines = markdown.split('\n');
+      let html = '';
+      let inList = false;
+      let listType = null;
+      let inTable = false;
+      let isFirstTableRow = true;
+      let tableHeaders = [];
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const trimmedLine = line.trim();
+        if (!trimmedLine) continue;
+        if (trimmedLine === '[TABLE_START]') {
+          if (inList) {
+            html += listType === 'ul' ? '</ul>\n' : '</ol>\n';
+            inList = false;
+            listType = null;
+          }
+          inTable = true;
+          isFirstTableRow = true;
+          html += '<div class="table-container"><table>\n';
+          continue;
+        }
+        if (trimmedLine.includes('|') && trimmedLine.split('|').length > 2) {
+          const cells = trimmedLine.split('|').map(cell => cell.trim()).filter(cell => cell);
+          if (!inTable) {
+            if (inList) {
+              html += listType === 'ul' ? '</ul>\n' : '</ol>\n';
+              inList = false;
+              listType = null;
+            }
+            html += '<div class="table-container"><table>\n';
+            inTable = true;
+            isFirstTableRow = true;
+          }
+          if (isFirstTableRow) {
+            tableHeaders = cells;
+            html += '<thead>\n<tr>\n';
+            cells.forEach(cell => { html += `<th>${cell}</th>\n`; });
+            html += '</tr>\n</thead>\n<tbody>\n';
+            isFirstTableRow = false;
+          } else {
+            html += '<tr>\n';
+            cells.forEach((cell, idx) => { const header = tableHeaders[idx] || ''; html += `<td data-label="${header}">${cell}</td>\n`; });
+            html += '</tr>\n';
+          }
+          continue;
+        }
+        if (inTable) {
+          html += '</tbody></table></div>\n';
+          inTable = false;
+          isFirstTableRow = true;
+          tableHeaders = [];
+        }
+        if (trimmedLine.startsWith('### ')) {
+          if (inList) { html += listType === 'ul' ? '</ul>\n' : '</ol>\n'; inList=false; listType=null; }
+          html += `<h3>${trimmedLine.substring(4)}</h3>\n`;
+        } else if (trimmedLine.startsWith('## ')) {
+          if (inList) { html += listType === 'ul' ? '</ul>\n' : '</ol>\n'; inList=false; listType=null; }
+          html += `<h2>${trimmedLine.substring(3)}</h2>\n`;
+        } else if (trimmedLine.startsWith('# ')) {
+          if (inList) { html += listType === 'ul' ? '</ul>\n' : '</ol>\n'; inList=false; listType=null; }
+          html += `<h1>${trimmedLine.substring(2)}</h1>\n`;
+        } else if (trimmedLine.startsWith('• ') || trimmedLine.startsWith('- ')) {
+          if (!inList || listType !== 'ul') {
+            if (inList && listType === 'ol') { html += '</ol>\n'; }
+            html += '<ul>\n';
+            inList = true;
+            listType = 'ul';
+          }
+          html += `<li>${trimmedLine.substring(2)}</li>\n`;
+        } else if (/^\d+\.\s/.test(trimmedLine)) {
+          if (!inList || listType !== 'ol') {
+            if (inList && listType === 'ul') { html += '</ul>\n'; }
+            html += '<ol>\n';
+            inList = true;
+            listType = 'ol';
+          }
+          html += `<li>${trimmedLine.replace(/^\d+\.\s/, '')}</li>\n`;
+        } else {
+          if (inList) { html += listType === 'ul' ? '</ul>\n' : '</ol>\n'; inList=false; listType=null; }
+          html += `<p>${trimmedLine}</p>\n`;
+        }
+      }
+      if (inList) { html += listType === 'ul' ? '</ul>\n' : '</ol>\n'; }
+      if (inTable) { html += '</tbody></table></div>\n'; }
+      return html;
+    }
+
+    function showPDF(url, name, container) {
+      const existingViewer = container.querySelector('.pdf-viewer, .ios-pdf-viewer');
+      if (existingViewer) existingViewer.remove();
+      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+      if (isIOS || isSafari) {
+        const iosViewer = document.createElement('div');
+        iosViewer.className = 'ios-pdf-viewer';
+        iosViewer.innerHTML = `
+          <div class="ios-pdf-message" style="text-align:center;padding:20px;background:rgba(255,255,255,0.2);border-radius:15px;border:1px solid rgba(255,255,255,0.3);">
+            <p style="margin-bottom:15px;color:var(--text-color);font-weight:500;">📱 ${name}</p>
+            <p style="margin-bottom:15px;color:var(--text-color);font-size:14px;">iOSデバイスではPDFを新しいタブで開きます</p>
+            <button onclick="window.open('${url}', '_blank', 'noopener,noreferrer')" style="padding:12px 20px;background:linear-gradient(135deg,rgba(255,145,115,0.85) 0%,rgba(255,138,101,0.85) 100%);color:white;border:none;border-radius:10px;cursor:pointer;font-size:16px;font-weight:600;border:2px solid rgba(255,255,255,0.3);backdrop-filter:blur(10px);transition:all 0.3s ease;">PDFを開く</button>
+          </div>`;
+        container.appendChild(iosViewer);
+      } else {
+        const iframe = document.createElement('iframe');
+        iframe.className = 'pdf-viewer';
+        iframe.src = url;
+        iframe.title = name;
+        iframe.style.cssText = `width:100%;height:400px;border:1px solid rgba(255,255,255,0.3);border-radius:15px;margin-top:15px;backdrop-filter:blur(10px);animation:fadeInUp 0.6s ease-out;`;
+        if (window.innerWidth >= 768) {
+          iframe.style.height = '70vh';
+          iframe.style.minHeight = '500px';
+          iframe.style.maxWidth = '100vw';
+        } else if (window.innerWidth < 480) {
+          iframe.style.height = '60vh';
+          iframe.style.minHeight = '';
+        }
+        container.appendChild(iframe);
+      }
+    }
+
+    async function showChildPageDetails(childPageId, container, button) {
+      const existing = container.querySelector('.child-page-details');
+      if (existing) return;
+      const originalText = button.textContent;
+      button.style.pointerEvents = 'none';
+      button.style.opacity = '0.6';
+      button.textContent = '読み込み中...';
+      try {
+        const response = await fetch(`/child-page/${childPageId}`);
+        if (!response.ok) throw new Error('HTTP error ' + response.status);
+        const data = await response.json();
+        let childDetailsSection = container.querySelector('.child-page-details');
+        if (!childDetailsSection) {
+          childDetailsSection = document.createElement('div');
+          childDetailsSection.className = 'child-page-details';
+          childDetailsSection.style.cssText = `margin-top:15px;padding:15px;background:rgba(255,255,255,0.05);border-radius:8px;border:1px solid rgba(255,255,255,0.1);`;
+          container.appendChild(childDetailsSection);
+        }
+        childDetailsSection.innerHTML = '';
+        if (data.files && data.files.length > 0) {
+          const filesTitle = document.createElement('h6');
+          filesTitle.textContent = 'ファイル:';
+          filesTitle.style.cssText = `margin:0 0 10px 0;color:var(--text-color);font-size:14px;`;
+          childDetailsSection.appendChild(filesTitle);
+          data.files.forEach(file => {
+            const fileDiv = document.createElement('div');
+            fileDiv.className = 'child-file-item';
+            fileDiv.style.cssText = `display:flex;align-items:center;margin:8px 0;padding:8px;background:rgba(255,255,255,0.1);border-radius:6px;font-size:14px;`;
+            const icon = document.createElement('span');
+            icon.textContent = '📄';
+            icon.style.marginRight = '8px';
+            const link = document.createElement('a');
+            link.href = file.url;
+            link.textContent = file.name;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            link.style.cssText = `color:var(--accent-color);text-decoration:none;flex:1;`;
+            link.onmouseover = () => link.style.textDecoration = 'underline';
+            link.onmouseout = () => link.style.textDecoration = 'none';
+            const viewBtn = document.createElement('button');
+            viewBtn.textContent = '表示';
+            const accentColor = getComputedStyle(document.documentElement).getPropertyValue('--accent-color').trim();
+            viewBtn.style.cssText = `padding:4px 8px;color:white;border:none;border-radius:4px;cursor:pointer;font-size:12px;margin-left:8px;`;
+            viewBtn.style.background = accentColor;
+            viewBtn.onclick = () => {
+              const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+              if (isIOS) {
+                window.open(file.url, '_blank', 'noopener,noreferrer');
+              } else {
+                showPDF(file.url, file.name, childDetailsSection);
+              }
+            };
+            fileDiv.appendChild(icon);
+            fileDiv.appendChild(link);
+            fileDiv.appendChild(viewBtn);
+            childDetailsSection.appendChild(fileDiv);
+          });
+        }
+        if (data.content && data.content.length > 0) {
+          const childContentBlocks = data.content.filter(block => block.type !== 'child_page');
+          let markdownContent = '';
+          childContentBlocks.forEach(block => {
+            if (block.type === 'paragraph' && block.paragraph.rich_text) {
+              const text = block.paragraph.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += text + '\n\n';
+            } else if (block.type === 'heading_1' && block.heading_1.rich_text) {
+              const text = block.heading_1.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '# ' + text + '\n\n';
+            } else if (block.type === 'heading_2' && block.heading_2.rich_text) {
+              const text = block.heading_2.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '## ' + text + '\n\n';
+            } else if (block.type === 'heading_3' && block.heading_3.rich_text) {
+              const text = block.heading_3.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '### ' + text + '\n\n';
+            } else if (block.type === 'bulleted_list_item' && block.bulleted_list_item.rich_text) {
+              const text = block.bulleted_list_item.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '• ' + text + '\n';
+            } else if (block.type === 'numbered_list_item' && block.numbered_list_item.rich_text) {
+              const text = block.numbered_list_item.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '1. ' + text + '\n';
+            } else if (block.type === 'table') {
+              markdownContent += '\n[TABLE_START]\n';
+            } else if (block.type === 'table_row' && block.table_row && block.table_row.cells) {
+              const cells = block.table_row.cells.map(cell => cell.map(text => text.plain_text).join('').trim());
+              markdownContent += '| ' + cells.join(' | ') + ' |\n';
+            }
+          });
+          if (markdownContent.trim()) {
+            const contentTitle = document.createElement('h6');
+            contentTitle.textContent = 'ページ内容:';
+            contentTitle.style.cssText = `margin:15px 0 10px 0;color:var(--text-color);font-size:14px;`;
+            childDetailsSection.appendChild(contentTitle);
+            const contentText = document.createElement('div');
+            contentText.className = 'child-page-text';
+            contentText.style.cssText = `font-size:14px;line-height:1.6;`;
+            contentText.innerHTML = parseMarkdownToHTML(markdownContent);
+            childDetailsSection.appendChild(contentText);
+          }
+        }
+        if ((!data.files || data.files.length === 0) && (!data.content || data.content.length === 0)) {
+          childDetailsSection.innerHTML = '<div style="color: #7f8c8d; font-style: italic; text-align: center; padding: 10px; font-size: 14px;">この子ページにはコンテンツがありません</div>';
+        }
+        button.style.pointerEvents = 'auto';
+        button.style.opacity = '1';
+        button.textContent = '子ページを閉じる';
+        button.onclick = () => {
+          childDetailsSection.style.display = 'none';
+          button.textContent = '子ページを表示';
+          button.onclick = () => {
+            childDetailsSection.style.display = 'block';
+            button.textContent = '子ページを閉じる';
+            button.onclick = () => {
+              childDetailsSection.style.display = 'none';
+              button.textContent = '子ページを表示';
+              button.onclick = () => {
+                childDetailsSection.style.display = 'block';
+                button.textContent = '子ページを閉じる';
+                button.onclick = arguments.callee.caller;
+              };
+            };
+          };
+        };
+      } catch (error) {
+        console.error('子ページ詳細の表示中にエラーが発生しました:', error);
+        button.style.pointerEvents = 'auto';
+        button.style.opacity = '1';
+        button.textContent = '子ページを表示';
+        let childDetailsSection = container.querySelector('.child-page-details');
+        if (!childDetailsSection) {
+          childDetailsSection = document.createElement('div');
+          childDetailsSection.className = 'child-page-details';
+          childDetailsSection.style.cssText = `margin-top:15px;padding:15px;background:rgba(255,255,255,0.05);border-radius:8px;border:1px solid rgba(255,255,255,0.1);`;
+          container.appendChild(childDetailsSection);
+        }
+        childDetailsSection.innerHTML = '<div style="color: #e74c3c; font-size:14px;">エラー: 子ページの詳細を取得できませんでした</div>';
+      }
+    }
+
+    async function loadPage(pageId) {
+      const container = document.getElementById('pageDetails');
+      try {
+        const res = await fetch(`/page/${pageId}`);
+        if (!res.ok) throw new Error('HTTP error ' + res.status);
+        const data = await res.json();
+        const title = formatProperty(data.page.properties['名前']) || 'タイトル不明';
+        document.getElementById('pageTitle').textContent = title;
+        if (data.files && data.files.length > 0) {
+          const filesSection = document.createElement('div');
+          filesSection.className = 'files-section';
+          const filesTitle = document.createElement('h4');
+          filesTitle.textContent = 'ファイル:';
+          filesSection.appendChild(filesTitle);
+          data.files.forEach(file => {
+            const fileDiv = document.createElement('div');
+            fileDiv.className = 'file-item';
+            const icon = document.createElement('span');
+            icon.className = 'pdf-icon';
+            icon.textContent = '📄';
+            const link = document.createElement('a');
+            link.className = 'file-link';
+            link.href = file.url;
+            link.textContent = file.name;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            const actionsDiv = document.createElement('div');
+            actionsDiv.className = 'file-actions';
+            const viewBtn = document.createElement('button');
+            viewBtn.className = 'file-btn';
+            viewBtn.textContent = '表示';
+            viewBtn.onclick = () => {
+              const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+              if (isIOS) {
+                window.open(file.url, '_blank', 'noopener,noreferrer');
+              } else {
+                showPDF(file.url, file.name, container);
+              }
+            };
+            const openTabBtn = document.createElement('button');
+            openTabBtn.className = 'file-btn open-tab';
+            openTabBtn.textContent = '新しいタブで開く';
+            openTabBtn.onclick = () => {
+              window.open(file.url, '_blank', 'noopener,noreferrer');
+            };
+            actionsDiv.appendChild(viewBtn);
+            const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+            if (!isIOS) actionsDiv.appendChild(openTabBtn);
+            fileDiv.appendChild(icon);
+            fileDiv.appendChild(link);
+            fileDiv.appendChild(actionsDiv);
+            filesSection.appendChild(fileDiv);
+          });
+          container.appendChild(filesSection);
+        }
+        if (data.childPages && data.childPages.length > 0) {
+          const childPagesTitle = document.createElement('h4');
+          childPagesTitle.textContent = '子ページ:';
+          childPagesTitle.style.marginTop = '20px';
+          container.appendChild(childPagesTitle);
+          data.childPages.forEach(childPage => {
+            const childPageDiv = document.createElement('div');
+            childPageDiv.className = 'child-page-item';
+            const childPageTitle = document.createElement('h5');
+            childPageTitle.textContent = childPage.title;
+            childPageTitle.style.cssText = 'margin:0 0 10px 0;color:var(--text-color);font-size:16px;';
+            childPageDiv.appendChild(childPageTitle);
+            if (childPage.error) {
+              const errorMsg = document.createElement('div');
+              errorMsg.textContent = childPage.error;
+              errorMsg.style.cssText = 'color:#e74c3c;font-style:italic;font-size:14px;';
+              childPageDiv.appendChild(errorMsg);
+            } else {
+              const showChildPageBtn = document.createElement('button');
+              showChildPageBtn.textContent = '子ページを表示';
+              showChildPageBtn.classList.add('child-page-btn');
+              showChildPageBtn.onclick = () => {
+                if (showChildPageBtn.style.pointerEvents === 'none' || showChildPageBtn.textContent === '読み込み中...' || !showChildPageBtn.parentNode) return;
+                showChildPageDetails(childPage.id, childPageDiv, showChildPageBtn);
+              };
+              childPageDiv.appendChild(showChildPageBtn);
+            }
+            container.appendChild(childPageDiv);
+          });
+        }
+        if (data.content && data.content.length > 0) {
+          const parentContentBlocks = data.content.filter(block => block.type !== 'child_page');
+          let markdownContent = '';
+          parentContentBlocks.forEach(block => {
+            if (block.type === 'paragraph' && block.paragraph.rich_text) {
+              const text = block.paragraph.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += text + '\n\n';
+            } else if (block.type === 'heading_1' && block.heading_1.rich_text) {
+              const text = block.heading_1.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '# ' + text + '\n\n';
+            } else if (block.type === 'heading_2' && block.heading_2.rich_text) {
+              const text = block.heading_2.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '## ' + text + '\n\n';
+            } else if (block.type === 'heading_3' && block.heading_3.rich_text) {
+              const text = block.heading_3.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '### ' + text + '\n\n';
+            } else if (block.type === 'bulleted_list_item' && block.bulleted_list_item.rich_text) {
+              const text = block.bulleted_list_item.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '• ' + text + '\n';
+            } else if (block.type === 'numbered_list_item' && block.numbered_list_item.rich_text) {
+              const text = block.numbered_list_item.rich_text.map(t => t.plain_text).join('');
+              if (text.trim()) markdownContent += '1. ' + text + '\n';
+            } else if (block.type === 'table') {
+              markdownContent += '\n[TABLE_START]\n';
+            } else if (block.type === 'table_row' && block.table_row && block.table_row.cells) {
+              const cells = block.table_row.cells.map(cell => cell.map(text => text.plain_text).join('').trim());
+              markdownContent += '| ' + cells.join(' | ') + ' |\n';
+            }
+          });
+          if (markdownContent.trim()) {
+            const contentDiv = document.createElement('div');
+            contentDiv.className = 'page-content';
+            contentDiv.style.marginTop = data.files && data.files.length > 0 || data.childPages && data.childPages.length > 0 ? '20px' : '0';
+            const contentTitle = document.createElement('h4');
+            contentTitle.textContent = 'メインページ内容:';
+            contentTitle.style.cssText = 'color:var(--text-color);margin-bottom:10px;font-size:16px;border-bottom:2px solid rgba(44,62,80,0.1);padding-bottom:5px;';
+            contentDiv.appendChild(contentTitle);
+            const contentText = document.createElement('div');
+            contentText.className = 'page-text';
+            contentText.innerHTML = parseMarkdownToHTML(markdownContent);
+            contentDiv.appendChild(contentText);
+            container.appendChild(contentDiv);
+          }
+        }
+        if ((!data.files || data.files.length === 0) && (!data.content || data.content.length === 0 || !hasActualContent(data.content))) {
+          const emptyMsg = document.createElement('div');
+          emptyMsg.style.cssText = 'color:var(--text-color); font-style:italic; text-align:center; padding:20px; background:rgba(255,255,255,0.1); border-radius:10px; border:1px dashed rgba(44,62,80,0.3);';
+          emptyMsg.textContent = 'ファイルとページ内容はありません';
+          container.appendChild(emptyMsg);
+        }
+      } catch(err) {
+        console.error(err);
+        container.innerHTML = '<div style="color:#e74c3c;">ページ詳細を取得できませんでした</div>';
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const id = getQueryParam('pageId');
+      if (id) {
+        loadPage(id);
+      } else {
+        document.getElementById('pageDetails').textContent = 'ページIDが指定されていません';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `public/page.html` to show details of a selected page
- change search results in `index.html` to open the new page using a button

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6877ce77a05c8328868bf0ddea63761a