### PR TITLE
Refine search results layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -526,20 +526,27 @@
       }
     }
     
+    #results {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+    }
+
     .result-item {
       background: var(--panel-bg);
       backdrop-filter: blur(25px);
       border: 2px solid rgba(255, 255, 255, 0.4);
-      margin: 15px 0;
+      margin: 0;
       padding: 20px;
       border-radius: 25px;
-      box-shadow: 
+      box-shadow:
         0 15px 35px rgba(0, 0, 0, 0.1),
         inset 0 2px 10px rgba(255, 255, 255, 0.3),
         0 0 50px rgba(135, 206, 235, 0.2);
       transition: all 0.3s ease;
       position: relative;
       overflow: hidden;
+      flex: 1 1 100%;
     }
     
     .result-item > * {
@@ -607,11 +614,12 @@
         0 0 35px rgba(135, 206, 235, 0.3);
     }
     
-    /* タブレチE��以上�Eサイズ */
+    /* タブレット以上のサイズ */
     @media (min-width: 768px) {
       .result-item {
-        margin: 20px 0;
+        margin: 0;
         padding: 25px;
+        flex-basis: calc(50% - 20px);
       }
       .result-title {
         font-size: 20px;
@@ -1509,7 +1517,8 @@
       
       .result-item {
         padding: 15px;
-        margin: 10px 0;
+        margin: 0;
+        flex-basis: 100%;
       }
       
       .result-title {
@@ -1617,6 +1626,10 @@
       #roseSVG {
         image-rendering: crisp-edges;
         image-rendering: -webkit-optimize-contrast;
+      }
+
+      .result-item {
+        flex-basis: calc(33.333% - 20px);
       }
     }
 


### PR DESCRIPTION
## Summary
- make results container flex with gaps
- set result item widths for responsive columns
- keep mobile single-column

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6877d817c40c832882f95df4f582c0a6