### PR TITLE
Improve page detail UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -540,7 +540,6 @@
       // 既にファイルセクションが存在する場合は何もしない
       const existingFilesSection = resultDiv.querySelector('.files-section');
       if (existingFilesSection) {
-        link.remove();
         return;
       }
       
@@ -549,6 +548,10 @@
       const originalPointerEvents = link.style.pointerEvents;
       const originalOpacity = link.style.opacity;
       const originalDisplay = link.style.display;
+      link.dataset.originalText = originalText;
+      link.dataset.originalPointer = originalPointerEvents;
+      link.dataset.originalOpacity = originalOpacity;
+      link.dataset.originalDisplay = originalDisplay;
       
       // リンクを無効化してローディング表示
       link.style.pointerEvents = 'none';
@@ -780,8 +783,21 @@
           console.log('Content exists (files, content, or child pages) - not showing empty message');
         }
         
-        // 成功時はリンクを完全に削除
-        link.remove();
+        // 閉じるボタンを追加
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = '内容を閉じる';
+        closeBtn.className = 'close-content-btn';
+        closeBtn.onclick = () => {
+          filesSection.remove();
+          link.style.pointerEvents = originalPointerEvents;
+          link.style.opacity = originalOpacity;
+          link.textContent = originalText || '展開';
+          link.style.display = originalDisplay || 'block';
+        };
+        filesSection.prepend(closeBtn);
+
+        // 元のリンクは非表示にする
+        link.style.display = 'none';
         
       } catch (error) {
         console.error('ページ詳細の表示中にエラーが発生しました:', error);

--- a/public/style.css
+++ b/public/style.css
@@ -1,14 +1,14 @@
 :root {
-  --base-color: #f2f2f2;
-  --main-color: #007bff;
-  --accent-color: #333;
+  --base-color: #f8fafc;
+  --main-color: #3498db;
+  --accent-color: #2c3e50;
 }
 * {
   box-sizing: border-box;
 }
 body {
   margin: 0;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  font-family: "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   background: var(--base-color);
   color: var(--accent-color);
   line-height: 1.5;
@@ -54,12 +54,14 @@ button:active {
 .search-btn,
 .file-btn,
 .child-page-btn,
-.show-details-btn {
+.show-details-btn,
+.close-content-btn {
   padding: 8px 16px;
   background: var(--main-color);
   color: #fff;
   border: none;
   border-radius: 4px;
+  margin-top: 4px;
 }
 .filters {
   display: flex;
@@ -98,7 +100,11 @@ select {
   transition: opacity 0.2s ease;
 }
 
-.file-btn.expand-btn:hover {
+.file-btn.expand-btn:hover,
+.search-btn:hover,
+.child-page-btn:hover,
+.show-details-btn:hover,
+.close-content-btn:hover {
   opacity: 0.85;
 }
 .result-item {
@@ -145,6 +151,13 @@ select {
 }
 .file-link:hover {
   text-decoration: underline;
+}
+.page-content {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 .loading-screen {
   position: fixed;


### PR DESCRIPTION
## Summary
- add a close button for page details
- polish fonts, colors, and container styling

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688b84d9bb9c8328845f03815f9808d5