### PR TITLE
Fix search panel layout on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -221,19 +221,19 @@ select {
 @media (max-width: 767px) {
   .search-panel {
     position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     margin: 0;
-    border-radius: 20px 20px 0 0;
-    transform: translateY(100%);
-    transition: transform 0.3s;
+    border-radius: 8px;
+    transition: none;
     max-height: 90vh;
     overflow-y: auto;
     z-index: 1001;
+    display: none;
   }
   .search-panel.open {
-    transform: translateY(0);
+    display: block;
   }
   #results {
     padding-bottom: 80px;


### PR DESCRIPTION
## Summary
- show the search panel as a centered modal on small screens

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8b09b9408328960f3065050a4ca0