### PR TITLE
Add mobile inline search panel display

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1334,6 +1334,7 @@
     window.addEventListener('DOMContentLoaded', () => {
       disableScroll();
       initializeSearchPanel();
+      handleSearchPanelOnScroll();
 
       const spinner = document.getElementById('spinnerContainer');
       if (spinner) {
@@ -1381,7 +1382,37 @@
     // ウィンドウリサイズ時の対応
     window.addEventListener('resize', () => {
       initializeSearchPanel();
+      handleSearchPanelOnScroll();
     });
+
+    // モバイル向け: スクロール位置に応じて検索パネル表示を切り替え
+    window.addEventListener('scroll', handleSearchPanelOnScroll);
+
+    function handleSearchPanelOnScroll() {
+      const panel = document.getElementById('searchPanel');
+      const fab = document.getElementById('fab');
+      const overlay = document.getElementById('searchPanelOverlay');
+
+      if (!panel || !fab) return;
+
+      // 非モバイル環境またはモーダル表示中は何もしない
+      if (window.innerWidth > 767 || isSearchPanelOpen) {
+        panel.classList.remove('search-panel-inline');
+        return;
+      }
+
+      if (window.scrollY <= 10) {
+        panel.classList.add('search-panel-inline', 'open');
+        fab.classList.add('hidden');
+        if (overlay) overlay.classList.remove('active');
+      } else {
+        panel.classList.remove('search-panel-inline');
+        panel.classList.remove('open');
+        fab.classList.remove('hidden');
+        if (overlay) overlay.classList.remove('active');
+        isSearchPanelOpen = false;
+      }
+    }
     // Enterキーで検索
     document.getElementById('searchInput')?.addEventListener('keypress', function(e) {
       if (e.key === 'Enter') {

--- a/public/style.css
+++ b/public/style.css
@@ -242,6 +242,13 @@ select {
   .search-panel.open {
     display: block;
   }
+  .search-panel-inline {
+    position: static;
+    transform: none;
+    display: block;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  }
   #results {
     padding-bottom: 80px;
   }


### PR DESCRIPTION
## Summary
- detect scroll position on mobile
- toggle search panel inline at page top and show FAB when scrolled
- style search panel inline for mobile

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688bb0d25f3c8328a20ab29148de2250